### PR TITLE
change transform to pose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(geometry_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Phase.msg"
-  "msg/SoleTransforms.msg"
+  "msg/SolePoses.msg"
   DEPENDENCIES std_msgs geometry_msgs
 )
 

--- a/msg/SolePoses.msg
+++ b/msg/SolePoses.msg
@@ -1,0 +1,4 @@
+# A message containing information about the poses of the robot's (l|r)_sole frames in
+# the torso frame. This message is useful for passing to inverse kinematics.
+geometry_msgs/Pose l_sole
+geometry_msgs/Pose r_sole

--- a/msg/SoleTransforms.msg
+++ b/msg/SoleTransforms.msg
@@ -1,4 +1,0 @@
-# A message containing information about the transform from the robot's torso frame
-# to it's (l|r)_sole frames. This message is useful for passing  to inverse kinematics.
-geometry_msgs/Transform l_sole
-geometry_msgs/Transform r_sole


### PR DESCRIPTION
Modifications from #5. I'm wondering if geometry_msgs/msg/Pose was better than geometry_msgs/msg/Transform... @SammyRamone what do you think?

The msg would then be called SolePoses.msg, and it would be the pose of the sole relative to the torso.

The two have the exact same msg, but have different meanings.